### PR TITLE
use conn pool and run concurrently

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,8 +6,10 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"sync"
 
 	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 const setupSQL = `drop table if exists j;
@@ -31,6 +33,29 @@ type Foo struct {
 func main() {
 	var memStats runtime.MemStats
 
+	connConfig, err := pgxpool.ParseConfig(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatalf("pgxpool.ParseConfig unexpectedly failed: %v", err)
+	}
+	connConfig.MaxConns = 50
+	pool, err := pgxpool.ConnectConfig(context.Background(), connConfig)
+	if err != nil {
+		log.Fatalf("pgxpool.ConnectConfig unexpectedly failed: %v", err)
+	}
+	defer pool.Close()
+
+	func() {
+		c, err := pool.Acquire(context.Background())
+		if err != nil {
+			log.Fatalf("pool.Acquire unexpectedly failed: %v", err)
+		}
+		defer c.Release()
+		_, err = pool.Exec(context.Background(), setupSQL)
+		if err != nil {
+			log.Fatalln("Unable to setup database:", err)
+		}
+	}()
+
 	conn, err := pgx.Connect(context.Background(), os.Getenv("DATABASE_URL"))
 	if err != nil {
 		log.Fatalln("Unable to connect to database:", err)
@@ -43,34 +68,42 @@ func main() {
 	}
 
 	for i := 0; i < 1000000000; i++ {
-		func() {
-			rows, err := conn.Query(context.Background(), "select data from j;")
-			if err != nil {
-				log.Fatalln("conn.Query unexpectedly failed:", err)
-			}
-			defer rows.Close()
+		var wg sync.WaitGroup
 
-			var result []*Foo
-			for rows.Next() {
-				var data Foo
-				scanErr := rows.Scan(&data)
-				if scanErr != nil {
-					log.Fatalln("rows.Scan unexpectedly failed:", scanErr)
+		for j := 0; j < 20; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				rows, err := pool.Query(context.Background(), "select data from j;")
+				if err != nil {
+					log.Fatalln("conn.Query unexpectedly failed:", err)
 				}
-				result = append(result, &data)
-			}
-			if err := rows.Err(); err != nil {
-				log.Fatalln("rows.Err() is not nil:", err)
-			}
-			if resLen := len(result); resLen != 3 {
-				log.Fatalln("len(result) is expected to be 3, but got", resLen)
-			}
+				defer rows.Close()
 
-			if i%100000 == 0 {
-				runtime.GC()
-				runtime.ReadMemStats(&memStats)
-				fmt.Printf("i=%d\tHeapAlloc=%d\tHeapObjects=%d\n", i, memStats.HeapAlloc, memStats.HeapObjects)
-			}
-		}()
+				var result []*Foo
+				for rows.Next() {
+					var data Foo
+					scanErr := rows.Scan(&data)
+					if scanErr != nil {
+						log.Fatalln("rows.Scan unexpectedly failed:", scanErr)
+					}
+					result = append(result, &data)
+				}
+				if err := rows.Err(); err != nil {
+					log.Fatalln("rows.Err() is not nil:", err)
+				}
+				if resLen := len(result); resLen != 3 {
+					log.Fatalln("len(result) is expected to be 3, but got", resLen)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		if i%100000 == 0 {
+			runtime.GC()
+			runtime.ReadMemStats(&memStats)
+			fmt.Printf("i=%d\tHeapAlloc=%d\tHeapObjects=%d\n", i, memStats.HeapAlloc, memStats.HeapObjects)
+		}
 	}
 }


### PR DESCRIPTION
I spotted two differences with the setup compared to the memory issue we observed in https://github.com/jackc/pgx/issues/845:

 - this uses one connection, and our usage had connection pool
 - our usage also ran concurrently

Added those and ran this for a while, and I cannot also seem to see the issue we have observed through pprof as you also observed at https://github.com/jackc/pgx/issues/845#issuecomment-713231116:

```
➜  pgx845 git:(master) ✗ go run main.go
i=0	HeapAlloc=1335232	HeapObjects=5002
i=100000	HeapAlloc=2736616	HeapObjects=7403
i=200000	HeapAlloc=2358248	HeapObjects=7027
i=300000	HeapAlloc=2121064	HeapObjects=6494
i=400000	HeapAlloc=2232296	HeapObjects=6723
i=500000	HeapAlloc=3145064	HeapObjects=9100
i=600000	HeapAlloc=3205160	HeapObjects=9201
i=700000	HeapAlloc=3540840	HeapObjects=9745
i=800000	HeapAlloc=3195432	HeapObjects=9375
i=900000	HeapAlloc=2965352	HeapObjects=8791
i=1000000	HeapAlloc=3228392	HeapObjects=9317
i=1100000	HeapAlloc=3366632	HeapObjects=9427
i=1200000	HeapAlloc=3238120	HeapObjects=9207
i=1300000	HeapAlloc=3103056	HeapObjects=9134
i=1400000	HeapAlloc=3191240	HeapObjects=9187
i=1500000	HeapAlloc=3416328	HeapObjects=9592
i=1600000	HeapAlloc=3151976	HeapObjects=9093
i=1700000	HeapAlloc=3121480	HeapObjects=9008
```